### PR TITLE
fix aligned allocation to unaligned

### DIFF
--- a/src/parser/t_string_blob.zig
+++ b/src/parser/t_string_blob.zig
@@ -67,11 +67,7 @@ pub const BlobStringParser = struct {
                 if (ptr.size == .c) size += @sizeOf(ptr.child);
 
                 const elemSize = std.math.divExact(usize, size, @sizeOf(ptr.child)) catch return error.LengthMismatch;
-                const res = try allocator.alignedAlloc(
-                    ptr.child,
-                    .of(T),
-                    elemSize,
-                );
+                const res = try allocator.alloc(ptr.child, elemSize);
                 errdefer allocator.free(res);
 
                 var bytes = mem.sliceAsBytes(res);


### PR DESCRIPTION
Hi!

I’m a newcomer to Zig (only a couple of days in), working on a small tool to get a feel for the language.

While experimenting, I ran into this issue:

```
error(gpa): Allocation alignment 8 does not match free alignment 1. Allocation:
.../.cache/zig/p/okredis-0.1.0-Cg726vcEBAAjrhwgBJ2cjL4qN3ircjBsX6iTd7wEFiEC/src/parser/t_string_blob.zig:70:55: 0x102e9980b in parseAlloc__anon_29778 (cleanup)
                const res = try allocator.alignedAlloc(
                                                      ^
---8<---

 Free:
.../.cache/zig/p/okredis-0.1.0-Cg726vcEBAAjrhwgBJ2cjL4qN3ircjBsX6iTd7wEFiEC/src/types/verbatim.zig:34:31: 0x102e89ddf in destroy__anon_28300 (cleanup)
                allocator.free(self.string);
                              ^
```

After some investigation (and with a nudge from ChatGPT), I found that replacing `alignedAlloc` with `alloc` resolves the problem.

I thought it might be worth submitting a PR with this fix — but please feel free to close it if you think this isn’t the right approach. I’m still very new to Zig and just learning how things work!