### PR TITLE
Refactor build.zig to to make it 0.15.x compatible

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,13 +3,15 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    
     const okredis = b.addModule("okredis", .{
-        .root_source_file = b.path("src/root.zig"),
-    });
-    const lib_unit_tests = b.addTest(.{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
+    });
+
+    const lib_unit_tests = b.addTest(.{
+        .root_module = okredis,
     });
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
     b.default_step.dependOn(&run_lib_unit_tests.step);
@@ -29,9 +31,11 @@ pub fn build(b: *std.Build) void {
     const example_step = b.step("example", "Build example");
     const simple_example = b.addExecutable(.{
         .name = "example",
-        .target = target,
-        .optimize = optimize,
-        .root_source_file = b.path("example.zig"),
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("example.zig"),
+            .target = target,
+            .optimize = optimize,
+        })
     });
     simple_example.root_module.addImport("okredis", okredis);
     const example_install = b.addInstallArtifact(simple_example, .{});
@@ -45,3 +49,4 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run-example", "Run the example");
     run_step.dependOn(&run_example.step);
 }
+


### PR DESCRIPTION
this pr includes the below listed changes to the build.zig
 1. fixed no field named 'root_source_file' error in lib_unit_tests
 2. includes target and optimizer to okredis *Module
 3. corrected simple example to use root_module 

