### PR TITLE
fix: port to Zig 0.16.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .okredis,
     .version = "0.1.0",
     .fingerprint = 0x3fa63be1eaf60e0a, // Changing this has security and trust implications.
-    .minimum_zig_version = "0.16.0-dev.1236+26db54d69",
+    .minimum_zig_version = "0.16.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/example.zig
+++ b/example.zig
@@ -8,7 +8,7 @@ pub fn main() !void {
     const gpa = std.heap.smp_allocator;
 
     // Pick your preferred Io implementation.
-    var threaded: Io.Threaded = .init(gpa);
+    var threaded: Io.Threaded = .init(gpa, .{});
     defer threaded.deinit();
     const io = threaded.io();
 

--- a/src/client.zig
+++ b/src/client.zig
@@ -133,7 +133,7 @@ pub fn pipeAlloc(
 const Pending = struct {
     // Protected by rl (readlock)
     state: enum { waiting, ready, canceled },
-    cond: Io.Condition = .{},
+    cond: Io.Condition = .init,
 
     // Protected by wl (writelock)
     next: ?*Pending = null,

--- a/src/parser/t_string_blob.zig
+++ b/src/parser/t_string_blob.zig
@@ -69,7 +69,7 @@ pub const BlobStringParser = struct {
                 const elemSize = std.math.divExact(usize, size, @sizeOf(ptr.child)) catch return error.LengthMismatch;
                 const res = try allocator.alignedAlloc(
                     ptr.child,
-                    .fromByteUnits(ptr.alignment),
+                    .fromByteUnits(ptr.alignment orelse @alignOf(ptr.child)),
                     elemSize,
                 );
                 errdefer allocator.free(res);
@@ -158,7 +158,10 @@ test "string" {
                 allocator,
                 &r_str4,
             );
-            defer allocator.free(s[0..12]);
+            defer {
+                const slice: []const u8 = s[0..12];
+                allocator.free(slice);
+            }
             try testing.expectEqualSlices(u8, s[0..13], "Hello World!\x00");
         }
         {
@@ -181,7 +184,10 @@ test "string" {
                 allocator,
                 &r_ji2,
             );
-            defer allocator.free(s[0..3]);
+            defer {
+                const slice: []const [4]u8 = s[0..3];
+                allocator.free(slice);
+            }
             try testing.expectEqualSlices(u8, "😈", &s[0]);
             try testing.expectEqualSlices(u8, "👿", &s[1]);
             try testing.expectEqualSlices(u8, &[4]u8{ 0, 0, 0, 0 }, &s[3]);

--- a/test/async.zig
+++ b/test/async.zig
@@ -8,7 +8,7 @@ const gpa = std.heap.smp_allocator;
 pub fn main() !void {
 
     // Pick your preferred Io implementation.
-    var threaded: Io.Threaded = .init(gpa);
+    var threaded: Io.Threaded = .init(gpa, .{});
     defer threaded.deinit();
     const io = threaded.io();
 


### PR DESCRIPTION
- Io.Threaded.init() now requires InitOptions as 2nd argument
- Io.Condition uses .init instead of .{}
- ptr.alignment changed from usize to ?usize in pointer type info
- C-pointer slice coercion requires explicit cast for allocator.free()