### PR TITLE
Add a TLS (`rediss://`) example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ pub fn main() !void {
 }
 ```
 
+## TLS (`rediss://`)
+
+Managed Redis (AWS ElastiCache/Valkey, Upstash, Redis Cloud, ...) requires an
+encrypted `rediss://` connection. Because `Client.init` takes a plain
+`Io.Reader`/`Io.Writer`, TLS is not an okredis feature: you wrap
+`std.crypto.tls` around the socket and hand okredis the *decrypted* stream.
+
+See [`tls_example.zig`](tls_example.zig) for a complete, runnable example
+(`zig build run-tls-example`). It performs the `std.crypto.tls` handshake over
+the raw socket, verifies the server certificate against the system root store
+(or accepts a self-signed dev cert with `REDIS_TLS_INSECURE=1`), and hands
+`tls_client.reader` plus a transport-flushing writer to `Client.init`.
+
+> Note: okredis flushes only the writer you pass it, but a `std.crypto.tls`
+> writer's `flush()` encrypts into the transport buffer without flushing the
+> socket, so the example wraps it in a tiny `Io.Writer` whose `flush` also
+> flushes the socket. See [#26](https://github.com/kristoff-it/zig-okredis/issues/26).
+
 ## Available Documentation
 The reference documentation [is available here](https://kristoff.it/zig-okredis#root).
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,9 @@ the raw socket, verifies the server certificate against the system root store
 (or accepts a self-signed dev cert with `REDIS_TLS_INSECURE=1`), and hands
 `tls_client.reader` plus a transport-flushing writer to `Client.init`.
 
-> Note: okredis flushes only the writer you pass it, but a `std.crypto.tls`
-> writer's `flush()` encrypts into the transport buffer without flushing the
-> socket, so the example wraps it in a tiny `Io.Writer` whose `flush` also
-> flushes the socket. See [#26](https://github.com/kristoff-it/zig-okredis/issues/26).
+> Note: a `std.crypto.tls` writer's `flush()` flushes only the TLS layer, not
+> the underlying socket (`std.http` flushes both), so the example wraps it in a
+> tiny `Io.Writer` whose `flush` also flushes the socket.
 
 ## Available Documentation
 The reference documentation [is available here](https://kristoff.it/zig-okredis#root).

--- a/build.zig
+++ b/build.zig
@@ -58,4 +58,23 @@ pub fn build(b: *std.Build) void {
 
     const run_step = b.step("run-example", "Run the example");
     run_step.dependOn(&run_example.step);
+
+    // TLS (rediss://) example
+    const tls_example_step = b.step("tls-example", "Build the TLS (rediss://) example");
+    const tls_example = b.addExecutable(.{
+        .name = "tls_example",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tls_example.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+    tls_example.root_module.addImport("okredis", okredis);
+    tls_example_step.dependOn(&b.addInstallArtifact(tls_example, .{}).step);
+    b.default_step.dependOn(tls_example_step);
+
+    const run_tls_example = b.addRunArtifact(tls_example);
+    const run_tls_step = b.step("run-tls-example", "Run the TLS (rediss://) example");
+    run_tls_step.dependOn(&run_tls_example.step);
 }

--- a/tls_example.zig
+++ b/tls_example.zig
@@ -1,0 +1,173 @@
+const std = @import("std");
+const Io = std.Io;
+const tls = std.crypto.tls;
+const Certificate = std.crypto.Certificate;
+
+const okredis = @import("okredis");
+const Client = okredis.Client;
+
+// Each TLS buffer must be able to hold at least one full TLS record.
+const tls_buf_len = tls.max_ciphertext_record_len;
+
+// Small env-var helper (this example links libc for `getenv`; a real app would
+// read configuration however it prefers).
+fn getEnv(name: [:0]const u8) ?[]const u8 {
+    return std.mem.span(std.c.getenv(name) orelse return null);
+}
+
+// --- The one piece TLS needs that a plain socket doesn't ---------------------
+//
+// okredis is bring-your-own-stream: `Client.init` takes an `Io.Reader` + an
+// `Io.Writer`, and after buffering a command it calls `writer.flush()`.
+//
+// Over a plain TCP socket that is enough: the socket writer's `flush` puts the
+// bytes on the wire. Over TLS it is NOT: `std.crypto.tls.Client.writer.flush()`
+// only *encrypts* the plaintext into the underlying transport writer's buffer -
+// it does not flush the transport. So a naive
+// `Client.init(io, &tls.reader, &tls.writer, ...)` writes HELLO, "flushes" it
+// into the socket buffer, and then blocks forever waiting for a reply the
+// server never received.
+//
+// `TlsTransport` is a tiny `Io.Writer` that closes that gap: on drain/flush it
+// encrypts through the TLS writer AND flushes the underlying socket, so okredis
+// can drive it exactly like a plain socket. (If okredis grew an optional
+// "flush the transport too" hook, this shim would go away.)
+const TlsTransport = struct {
+    tls: *tls.Client,
+    sock: *Io.Writer,
+    writer: Io.Writer,
+
+    const vtable: Io.Writer.VTable = .{ .drain = drain };
+
+    fn init(tls_client: *tls.Client, sock: *Io.Writer, buffer: []u8) TlsTransport {
+        return .{
+            .tls = tls_client,
+            .sock = sock,
+            .writer = .{ .buffer = buffer, .vtable = &vtable },
+        };
+    }
+
+    fn drain(w: *Io.Writer, data: []const []const u8, splat: usize) Io.Writer.Error!usize {
+        const self: *TlsTransport = @fieldParentPtr("writer", w);
+        const tw = &self.tls.writer;
+
+        var total: usize = 0;
+        const buffered = w.buffered();
+        if (buffered.len != 0) {
+            try tw.writeAll(buffered);
+            total += buffered.len;
+        }
+        for (data[0 .. data.len - 1]) |bytes| {
+            try tw.writeAll(bytes);
+            total += bytes.len;
+        }
+        const last = data[data.len - 1];
+        for (0..splat) |_| {
+            try tw.writeAll(last);
+            total += last.len;
+        }
+
+        try tw.flush(); // encrypt plaintext into the socket writer's buffer
+        try self.sock.flush(); // push the ciphertext onto the wire
+        return w.consume(total);
+    }
+};
+
+// Connecting to a `rediss://` endpoint (AWS ElastiCache/Valkey, Upstash, Redis
+// Cloud, ...) is just "wrap std.crypto.tls around the socket and hand okredis
+// the decrypted stream".
+//
+//   Managed Redis (publicly-trusted cert):
+//     REDIS_HOST=my-cache.abc123.serverless.usw2.cache.amazonaws.com \
+//     REDIS_ADDR=<resolved ip> REDIS_PORT=6379 REDIS_PASS=... \
+//     zig build run-tls-example
+//
+//   Dev server with a self-signed cert (relaxes verification):
+//     REDIS_TLS_INSECURE=1 REDIS_ADDR=127.0.0.1 REDIS_PORT=6380 \
+//     zig build run-tls-example
+pub fn main() !void {
+    const gpa = std.heap.smp_allocator;
+
+    var threaded: Io.Threaded = .init(gpa, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // --- configuration (points at a rediss:// endpoint) ---
+    // `host` is used for TLS SNI + certificate hostname verification. We connect
+    // to `REDIS_ADDR` (a literal IPv4 here for brevity - resolving a hostname to
+    // an address is the caller's job, same as in the non-TLS example).
+    const host = getEnv("REDIS_HOST") orelse "localhost";
+    const ip = getEnv("REDIS_ADDR") orelse "127.0.0.1";
+    const port: u16 = if (getEnv("REDIS_PORT")) |p|
+        try std.fmt.parseInt(u16, p, 10)
+    else
+        6379;
+    // Leave unset for managed Redis: the server presents a publicly-trusted cert
+    // that we verify against the system root store, with hostname verification.
+    // Set REDIS_TLS_INSECURE=1 to talk to a dev server using a self-signed cert.
+    const insecure = getEnv("REDIS_TLS_INSECURE") != null;
+
+    // --- plain TCP connection (managing it is your responsibility) ---
+    const addr: Io.net.IpAddress = try .parseIp4(ip, port);
+    const conn = try addr.connect(io, .{ .mode = .stream });
+    defer conn.close(io);
+
+    // Socket-side buffers carry encrypted bytes; each must hold a full TLS record.
+    var sock_rbuf: [tls_buf_len]u8 = undefined;
+    var sock_wbuf: [tls_buf_len]u8 = undefined;
+    var sock_reader = conn.reader(io, &sock_rbuf);
+    var sock_writer = conn.writer(io, &sock_wbuf);
+
+    // TLS-side buffers carry the plaintext that okredis reads/writes.
+    var tls_rbuf: [tls_buf_len]u8 = undefined;
+    var tls_wbuf: [tls_buf_len]u8 = undefined;
+
+    var entropy: [tls.Client.Options.entropy_len]u8 = undefined;
+    io.random(&entropy);
+    const now = Io.Clock.real.now(io);
+
+    // System root CA bundle (only used when verifying a real server cert).
+    var ca_bundle: Certificate.Bundle = .empty;
+    defer ca_bundle.deinit(gpa);
+    var ca_lock: Io.RwLock = .init;
+    if (!insecure) try ca_bundle.rescan(gpa, io, now);
+
+    // Perform the TLS handshake over the raw socket reader/writer.
+    var tls_client = try tls.Client.init(
+        &sock_reader.interface,
+        &sock_writer.interface,
+        .{
+            .host = if (insecure) .no_verification else .{ .explicit = host },
+            .ca = if (insecure) .self_signed else .{ .bundle = .{
+                .gpa = gpa,
+                .io = io,
+                .lock = &ca_lock,
+                .bundle = &ca_bundle,
+            } },
+            .read_buffer = &tls_rbuf,
+            .write_buffer = &tls_wbuf,
+            .entropy = &entropy,
+            .realtime_now = now,
+        },
+    );
+
+    // Wrap the TLS writer so that okredis's `flush()` also flushes the socket.
+    var xport_buf: [tls_buf_len]u8 = undefined;
+    var transport = TlsTransport.init(&tls_client, &sock_writer.interface, &xport_buf);
+
+    // Optional AUTH (managed Redis usually requires a password / ACL user).
+    const auth: ?Client.Auth = if (getEnv("REDIS_PASS")) |pass|
+        .{ .user = getEnv("REDIS_USER"), .pass = pass }
+    else
+        null;
+
+    // Hand okredis the decrypted TLS reader and the transport-flushing writer.
+    // Everything else (RESP3, pipelining, typed replies) works unchanged.
+    var client = try Client.init(io, &tls_client.reader, &transport.writer, auth);
+
+    try client.send(void, .{"PING"});
+    try client.send(void, .{ "SET", "okredis:tls", "hello over TLS" });
+
+    const reply = try client.send(okredis.types.FixBuf(64), .{ "GET", "okredis:tls" });
+    std.debug.print("GET okredis:tls => {s}\n", .{reply.toSlice()});
+}

--- a/tls_example.zig
+++ b/tls_example.zig
@@ -15,23 +15,17 @@ fn getEnv(name: [:0]const u8) ?[]const u8 {
     return std.mem.span(std.c.getenv(name) orelse return null);
 }
 
-// --- The one piece TLS needs that a plain socket doesn't ---------------------
+// --- Composing a TLS stream for okredis --------------------------------------
 //
-// okredis is bring-your-own-stream: `Client.init` takes an `Io.Reader` + an
-// `Io.Writer`, and after buffering a command it calls `writer.flush()`.
+// okredis is bring-your-own-stream: it writes commands to the `Io.Writer` you
+// pass and calls `writer.flush()`. For a plain socket that puts the bytes on
+// the wire. A `std.crypto.tls` writer's `flush()`, by design, flushes only the
+// TLS layer - it encrypts into the underlying socket writer's buffer but does
+// not flush the socket (`std.http` likewise flushes both layers explicitly).
 //
-// Over a plain TCP socket that is enough: the socket writer's `flush` puts the
-// bytes on the wire. Over TLS it is NOT: `std.crypto.tls.Client.writer.flush()`
-// only *encrypts* the plaintext into the underlying transport writer's buffer -
-// it does not flush the transport. So a naive
-// `Client.init(io, &tls.reader, &tls.writer, ...)` writes HELLO, "flushes" it
-// into the socket buffer, and then blocks forever waiting for a reply the
-// server never received.
-//
-// `TlsTransport` is a tiny `Io.Writer` that closes that gap: on drain/flush it
-// encrypts through the TLS writer AND flushes the underlying socket, so okredis
-// can drive it exactly like a plain socket. (If okredis grew an optional
-// "flush the transport too" hook, this shim would go away.)
+// So we hand okredis a small `Io.Writer` whose flush encrypts through the TLS
+// writer AND flushes the socket; otherwise a command would sit unsent in the
+// socket buffer.
 const TlsTransport = struct {
     tls: *tls.Client,
     sock: *Io.Writer,


### PR DESCRIPTION
okredis is bring-your-own-stream, so connecting to a managed `rediss://` endpoint (AWS ElastiCache/Valkey, Upstash, Redis Cloud) just means wrapping `std.crypto.tls` around the socket and handing okredis the decrypted stream. There wasn't an example for it, so here's one.

### What's here

- **`tls_example.zig`** — performs the `std.crypto.tls` handshake over the raw socket, verifies the server certificate against the **system root store** with hostname verification (or accepts a **self-signed dev cert** with `REDIS_TLS_INSECURE=1`), and hands `tls_client.reader` plus a writer to `Client.init`.
- **`build.zig`** — a `tls-example` / `run-tls-example` step, mirroring the existing `example`.
- **`README.md`** — a short "TLS (`rediss://`)" section.

One small non-obvious bit, noted in a comment and the README: a `std.crypto.tls` writer's `flush()` flushes only the TLS layer, not the underlying socket (the same reason `std.http`'s connection flush flushes both), so the example gives okredis a tiny `Io.Writer` whose flush also flushes the socket.

### Testing

On Zig 0.16.0 against `redis-server --tls` (self-signed):

```
$ REDIS_TLS_INSECURE=1 REDIS_ADDR=127.0.0.1 REDIS_PORT=6380 zig build run-tls-example
GET okredis:tls => hello over TLS
```

and confirmed server-side that the write landed over the encrypted connection. `zig fmt --check` is clean.

Purely additive — an example plus docs, no changes to the library itself. For context, we run Zig in production at Strobe ([`eth.zig`](https://github.com/StrobeLabs/eth.zig), [`perpcity-zig-sdk`](https://github.com/StrobeLabs/perpcity-zig-sdk)) and okredis is our pick for the Redis side. Thanks for the library.
